### PR TITLE
add :3 webring to nav

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -46,7 +46,15 @@
             <figcaption>work</figcaption>
           </figure>
         </a></li>
+        <li>
+          <div>
+            <a class="textlink" href="https://leviv.cool/">←</a>
+            <p class="caption">:3 ring</p>
+            <a class="textlink" href="https://lyuu.cc/">→</a>
+          </div>
+        </li>
       </ul>
+      
     </nav>
     <main>
       <div id="main-content">

--- a/src/style.css
+++ b/src/style.css
@@ -124,6 +124,21 @@ figcaption {
   border-radius: 30%;
 }
 
+.caption {
+  font-size: large;
+  background-color: var(--accent-color);
+  border: hidden;
+  border-radius: 30%;
+}
+
+.textlink:hover {
+  filter: hue-rotate(-130deg) sepia(0.3);
+  background-color: rgba(255, 255, 255, 0.1);
+  border: 2px dashed var(--accent-color);
+  border-radius: 50%;
+  transition-duration: 0.3s;
+}
+
 main {
   z-index: 0;
   position: absolute;


### PR DESCRIPTION
<img width="370" height="744" alt="image" src="https://github.com/user-attachments/assets/9218b694-3bbd-409c-914b-04cc783349c5" />

another addition to the navbar! levi and I started the ":3 ring" inspired by the web ring [bob's club](https://bobs-club.net/).

it's wonky on small mobile screens but I guess the whole site is a bit wonky on those.
<img width="376" height="666" alt="image" src="https://github.com/user-attachments/assets/c7064966-7f24-4b6f-a035-8d93500d4230" />

it's better on bigger mobile screens:
<img width="410" height="915" alt="image" src="https://github.com/user-attachments/assets/09dbc4df-2115-4f38-9811-ff1d4c320439" />


